### PR TITLE
adds sgoley/"postgres_utils" to hub

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -37,5 +37,8 @@
     ],
     "kristeligt-dagblad": [
         "dbt_ml"
+    ],
+    "sgoley": [
+        "postgres_utils"
     ]
 }


### PR DESCRIPTION
Initial release is just for the `index` & `unique index` that are essential tools for postgres. 

Full project plan available here: https://github.com/sgoley/dbt-postgres-utils/projects/1

Is there any base "maturity" requirements that you look for in dbtHub packages or this enough to start? 
I can do more development on that side and then re-submit later. 