### PR TITLE
Add dbtvault from Datavault-UK

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -71,5 +71,8 @@
     ],
     "sgoley": [
         "dbt-postgres-utils"
+    ],
+    "Datavault-UK": [
+        "dbtvault"
     ]
 }


### PR DESCRIPTION
Adding the dbtvault package to dbt hub. 

https://dbtvault.readthedocs.io/en/latest/