### PR TITLE
Add spark-utils

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -18,6 +18,7 @@
         "redshift",
         "segment",
         "ecommerce",
+        "spark-utils",
         "stitch-utils",
         "dbt-codegen",
         "dbt-audit-helper",


### PR DESCRIPTION
This package leverages "dispatched" macros (new in v0.18.0) to get other packages running on a non-core plugin (Spark). I hope this might be a model for other community-contributed plugins + packages.