### PR TITLE
Add yu-iskw/dbt-airflow-macros

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -90,6 +90,9 @@
     "calogica": [
         "dbt-date",
         "dbt-expectations"
+    ],
+    "yu-iskw": [
+        "dbt-airflow-macros"
     ]
 
 }


### PR DESCRIPTION
## Motivation to create the package
I used to use Apache Airflow to run scheduled BigQuery queries. and still use Apache Airflow to schedule dbt jobs. When we migrate them to dbt, we have to take in account “execution date”. As you might know, airflow provides its unique macros as ds  and ts . So, I just implemented a dbt package inspired by airflow macros to deal with “execution date”.

Please see the documentation.
* https://github.com/yu-iskw/dbt-airflow-macros