### PR TITLE
Add dbtplyr to hub.json

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -124,6 +124,9 @@
     ],
     "tailsdotcom": [
         "dbt_artifacts"
+    ],
+    "emilyriederer": [
+        "dbtplyr"
     ]
 
 }


### PR DESCRIPTION
This PR adds my lightweight `dbtplyr` package. This package borrows the semantics of R's `dplyr` package to enable useful column selectors based on naming components (`starts_with()`, `ends_with()`) and the ability to add either transformations (to SELECT) or filters (to WHERE) across many columns in parallel (with `across()`, `c_across()`, `if_all()`, `if_any()`)

I will highlight this is a much smaller, more modest package than most on the Hub. Of course, I understand if it isn't a fit, but I thought I would submit it for consideration. Thanks!