### PR TITLE
Add Meltano-managed dbt packages (WIP)

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -86,6 +86,18 @@
         "dbt_iterable_source",
         "dbt_salesforce_formula_utils"
     ],
+    "Meltano": [
+        "dbt-tap-adwords",
+        "dbt-tap-carbon-intensity",
+        "dbt-tap-facebook",
+        "dbt-tap-gitlab",
+        "dbt-tap-google-analytics",
+        "dbt-tap-salesforce",
+        "dbt-tap-shopify",
+        "dbt-tap-stripe",
+        "dbt-tap-zendesk",
+        "dbt-tap-zuora",
+    ]
     "Montreal-Analytics": [
         "dbt-snowflake-utils"
     ],


### PR DESCRIPTION
It looks like this requires our repos to be moved to GitHub. Currently we are only hosting these on GitLab.com.

Before this is ready to merge:

- [ ] Migrate (or mirror) repos from Gitlab to Github
- [ ] Publish at least one semvar release for each repo

Repos on gitlab are here: https://gitlab.com/meltano?filter=dbt-
