### PR TITLE
Remove nonexistent or private packages.

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -141,10 +141,6 @@
     "re-data": [
         "dbt-re-data"
     ],
-    "beautypie": [
-        "dbt-google-analytics-360",
-        "dbt-zendesk-support"
-    ],
     "mjirv": [
         "dbt-datamocktool"
     ],


### PR DESCRIPTION
These two don't exist and are failing the build of the script! We need them removed so the script can finish cycling through all packages.