### PR TITLE
Handle the case when packages.yml is empty

### DIFF
--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -41,7 +41,7 @@ def parse_pkgs(repo_dir):
     if os.path.exists(repo_dir / "packages.yml"):
         with open(repo_dir / Path("packages.yml"), "r") as stream:
             pkgs = yaml.safe_load(stream)
-            return pkgs.get("packages",[]) if pkgs else []
+            return pkgs.get("packages", []) if pkgs else []
     else:
         return []
 


### PR DESCRIPTION
Fix the script in case a `packages.yml` exists but is not valid yml (or is empty).