### PR TITLE
Fix accidental misnaming in #385

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -476,7 +476,7 @@
     ],
     "windsor-ai": [
         "dbt_facebook_ads",
-        "salesforce_campaign_funnel"
+        "dbt-bigquery-package-for-salesforce"
     ],
     "xoniks": [
         "dbt-test-results"


### PR DESCRIPTION
## Problem
Within https://github.com/dbt-labs/hubcap/pull/385, I should have used the name of the GitHub repo, but I incorrectly used the dbt package name within `dbt_project.yml` instead.

## Solution
Replace with the name of the GitHub repo here:
https://github.com/windsor-ai/dbt-bigquery-package-for-salesforce