### PR TITLE
Add TheDamiofLagos with dbt-contract-gen to hub.json

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -136,6 +136,9 @@
     "Teradata": [
         "dbt-teradata-utils"
     ],
+    "TheDamiofLagos": [
+        "dbt-contract-gen"
+    ],
     "Velir": [
         "dbt-ga4"
     ],


### PR DESCRIPTION
## Description

A Snowflake macro package that generates dbt contract YAML by introspecting a model's columns directly from the warehouse via `adapter.get_columns_in_relation()`. Run one command, copy the YAML output, paste it into your model's `.yml` file — no manual column listing required.

Link to repository: https://github.com/TheDamiofLagos/dbt-contract-gen

## Checklist

### Real world usage
- [x] I have been using this package in production and am satisfied with its behavior.

> The package has been tested end-to-end against a live Snowflake environment including seed, run, and contract generation across multiple fact models. Production usage is in progress.

### First run experience
- [x] The package includes a licence file (MIT)
- [x] The README explains how to get started and customise behaviour
- [x] The README indicates Snowflake as the only supported warehouse

### Customisability
- [x] The package uses no hard-coded table references — model name and schema are passed as arguments

### Dependencies
- [x] `require-dbt-version` is set to `[">=1.5.0", "<2.0.0"]`
- The package has no dependencies on other packages

### Interoperability
- [x] The package does not override any dbt Core behaviour
- [x] The macro name `generate_contract_yml` is sufficiently unique to avoid clashes

### Versioning
- [x] Git tag `v0.1.2` follows semantic versioning
