### PR TITLE
Add UniRate-API/dbt-unirate

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -96,7 +96,7 @@
         "dbt-ml-eval",
         "dbt-orphan"
     ],
-    "metaplane" : [
+    "metaplane": [
         "dbt-expectations"
     ],
     "Montreal-Analytics": [
@@ -532,5 +532,8 @@
     ],
     "teoria": [
         "dbt-iceberg-utils"
+    ],
+    "UniRate-API": [
+        "dbt-unirate"
     ]
 }

--- a/hub.json
+++ b/hub.json
@@ -536,5 +536,8 @@
     ],
     "teoria": [
         "dbt-iceberg-utils"
+    ],
+    "UniRate-API": [
+        "dbt-unirate"
     ]
 }


### PR DESCRIPTION
### Add `UniRate-API/dbt-unirate` to the dbt Package Hub

This PR adds [`UniRate-API/dbt-unirate`](https://github.com/UniRate-API/dbt-unirate) to `hub.json`.

**What the package does**

`dbt-unirate` provides currency conversion in dbt, powered by the [UniRateAPI](https://unirateapi.com) public exchange-rates API:

- A Python model that pulls live rates from `/api/rates` and materialises a long-format `unirate__exchange_rates` table (`as_of_date`, `base_currency`, `target_currency`, `rate`).
- An optionally-enabled Python model that back-fills history from `/api/historical/timeseries` (UniRate Pro plan).
- Three adapter-agnostic Jinja macros — `unirate.convert_currency`, `unirate.get_rate`, `unirate.get_historical_rate` — for inline use in any model.

The motivating use case is dbt Discourse [#364 — Currency Conversions in dbt](https://discourse.getdbt.com/t/currency-conversions-in-dbt/364), one of the most-viewed evergreen forum threads. The recommended pattern there is "build your own rates table plus a `convert_currency` macro" — this package is that pattern, batteries-included.

**Hubcap checklist**

- [x] Hosted on GitHub: <https://github.com/UniRate-API/dbt-unirate>
- [x] `dbt_project.yml` declares `name: 'unirate'`
- [x] No `packages.yml` at repository root (no transitive dbt deps)
- [x] Semantic-versioned release tag: [`v0.1.0`](https://github.com/UniRate-API/dbt-unirate/releases/tag/v0.1.0)
- [x] MIT [LICENSE](https://github.com/UniRate-API/dbt-unirate/blob/main/LICENSE)
- [x] README documents install + first-run + adapter coverage
- [x] `require-dbt-version: [">=1.8.0", "<2.0.0"]`
- [x] All resources prefixed `unirate__*` / `unirate.*` to avoid collisions
- [x] Macros use `ref()` exclusively; no hard-coded relations
- [x] Adapter coverage: macros are pure SQL (any adapter); Python models target Snowflake / Databricks / BigQuery; README documents the seed-based fallback for adapters without Python-model support
- [x] CI runs `dbt build` against DuckDB on dbt 1.8 and 1.9 — [latest run green](https://github.com/UniRate-API/dbt-unirate/actions)

**Disclosure**

I'm the maintainer of UniRateAPI and built this package; the dbt-side macros and table schema are adapter-agnostic and decoupled from UniRate (you can swap the rates source by passing `rates_relation=ref('your_table')` to any macro).

This PR was prepared with assistance from an AI agent (Claude Code).

Happy to address any feedback — thanks for maintaining the hub!
