### PR TITLE
Add civitaspo/dbt-authorized-models package

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -173,6 +173,9 @@
         "airbyte_dbt_shopify",
         "airbyte_dbt_stripe"
     ],
+    "civitaspo": [
+        "dbt-authorized-models"
+    ],
     "creativeautomation": [
         "dbt-airbyte-shopify"
     ],


### PR DESCRIPTION
## Description

Adds [civitaspo/dbt-authorized-models](https://github.com/civitaspo/dbt-authorized-models) to the dbt Package Hub.

**dbt-authorized-models** is a dbt package for enforcing explicit authorization rules on model references. Model owners can declare `config.meta.authorize` rules on referenced models, and downstream references are checked against regex-based properties such as `resource_type`, `database`, `schema`, `identifier`, `tags`, and `package_name`.

The package is intended for teams that want BigQuery authorized-view-style dependency controls inside dbt projects. It is deny-by-default for protected models, opt-in via an `on-run-start` hook, and warehouse-agnostic because it inspects dbt graph metadata rather than issuing warehouse-specific SQL.

Link to your package's repository: https://github.com/civitaspo/dbt-authorized-models

Latest release: https://github.com/civitaspo/dbt-authorized-models/releases/tag/v0.1.0

## Checklist

_This checklist is based on the package best practices in this repository. I am keeping this PR in draft while I review the submission details before marking it ready for dbt Labs review._

### First run experience
- [x] (Required): The package includes a licence file detectable by GitHub: Apache License 2.0.
- [x] The package includes a README which explains how to get started with the package and customise its behaviour.
- [x] The README indicates which platforms are expected to work with this package: dbt Core 1.10+ and dbt Fusion 2.0 preview.
- [x] The package is warehouse-agnostic; integration tests run with DuckDB, and the package logic uses dbt graph metadata rather than warehouse-specific SQL.

### Customisability
- [x] The package uses dbt graph metadata and `ref` dependencies instead of hard-coding table references.
- [x] The package exposes variables for enforcement mode and excluded referencing resource types.

#### Packages for data transformation
_Not relevant — this is a macro-only authorization package, not a data transformation package. It does not create models, sources, or warehouse relations._

### Dependencies
#### Dependencies on dbt Core
- [x] The package has set a supported `require-dbt-version` range in `dbt_project.yml`: `[">=1.10.0", "<2.0.0"]`.

#### Dependencies on other packages defined in packages.yml
- [x] The package has no runtime package dependencies.
- [x] The integration test project uses local development installation plus dbt-unittest, but those are not runtime dependencies of the published package.

### Interoperability
- [x] The package does not override dbt Core behaviour in such a way as to impact other dbt resources not provided by the package.
- [x] The package is opt-in: users enable checks from their root project's `on-run-start` hook.
- [x] The package disambiguates its macros under the `dbt_authorized_models` namespace.
- [x] The package does not provide generic model names that could clash with user project nodes.
- [x] CI covers dbt Core and dbt Fusion compatibility.

### Versioning
- [x] (Required): The package's git tag validates against the regex defined in `hubcap/version.py`: `v0.1.0`.
- [x] The package's version follows the guidance of Semantic Versioning 2.0.0, starting at `0.1.0` for the initial public release.

## Verification

- `python -m json.tool hub.json`
- `uv run --extra test pytest`
