### PR TITLE
Update hub.json for `dbt-healthcare-standards` package

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -129,6 +129,9 @@
     "shankararul": [
         "dbt_eda_tools"
     ],
+    {
+  "git": "https://github.com/smudvar/dbt-healthcare-standards.git"
+}
     "Snowflake-Labs": [
         "dbt_constraints",
         "dbt_semantic_view"
@@ -464,6 +467,9 @@
     "smithclay": [
         "dbt_opentelemetry"
     ],
+    "smudvar": [
+    "dbt-healthcare-standards"
+        ],
     "snowplow": [
         "dbt-snowplow-utils",
         "dbt-snowplow-web",


### PR DESCRIPTION
Adding dbt-healthcare-standards package —
ISO-11179 naming convention macros and 
tests for healthcare dbt projects.

Covers claims, clinical, pharmacy, member,
and provider domains with 100,000+ term
reference at mdatool.com/glossary

## Description 

_Tell us about your new package!_

Link to your package's repository: https://github.com/smudvar/dbt-healthcare-standards

## Checklist
_This checklist is a cut down version of the [best practices](../blob/main/package-best-practices.md) that we have identified as the package hub has grown. Although meeting these checklist items is not a prerequisite to being added to the Hub, we have found that packages which don't conform provide a worse user experience._

### Real world usage

Using coding agents to help you build your package is totally fine, but please don't submit it to the package hub until you've used it in your own production environment for an extended period of time.

- [ ] (Required): I have been using this package in production and am satisfied with its behavior.

### First run experience
- [ ] (Required): The package includes a [licence file detectable by GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository), such as the Apache 2.0 or MIT licence.
- [ ] The package includes a README which explains how to get started with the package and customise its behaviour
- [ ] The README indicates which data warehouses/platforms are expected to work with this package

### Customisability
- [ ] The package uses ref or source, instead of hard-coding table references.
#### Packages for data transformation (delete if not relevant):
- [ ] provide a mechanism (such as variables) to customise the location of source tables.
- [ ] do not assume database/schema names in sources.

### Dependencies
#### Dependencies on dbt Core
- [ ] The package has set a supported `require-dbt-version` range in `dbt_project.yml`. Example: A package which depends on functionality added in dbt Core 1.2 should set its `require-dbt-version` property to `[">=1.2.0", "<2.0.0"]`.
#### Dependencies on other packages defined in packages.yml:
- [ ] Dependencies are imported from the dbt Package Hub when available, as opposed to a git installation.
- [ ] Dependencies contain the widest possible range of supported versions, to minimise issues in dependency resolution.
- [ ] In particular, dependencies are not pinned to a patch version unless there is a known incompatibility.
### Interoperability
- [ ] The package does not override dbt Core behaviour in such a way as to impact other dbt resources (models, tests, etc) not provided by the package.
- [ ] The package uses the cross-database macros built into dbt Core where available, such as `{{ dbt.except() }}` and `{{ dbt.type_string() }}`.
- [ ] The package disambiguates its resource names to avoid clashes with nodes that are likely to already exist in a project. For example, packages should not provide a model simply called `users`.

### Versioning
- [ ] (Required): The package's git tags validates against the regex defined in `hubcap/version.py` ([examples](https://regex101.com/r/OHA92c)). 
- [ ] The package's version follows the guidance of Semantic Versioning 2.0.0. (Note in particular the recommendation for production-ready packages to be version 1.0.0 or above)
