### PR TITLE
Add jaysobel/dbt-cron-timestamps

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -399,6 +399,9 @@
     "irvingpop": [
         "dbt_otel_export"
     ],
+    "jaysobel": [
+        "dbt-cron-timestamps"
+    ],
     "jitsucom": [
         "dbt-jitsu"
     ],


### PR DESCRIPTION
## Description

Add `jaysobel/dbt-cron-timestamps`, a Snowflake macro package that constructively generates matching timestamps from five-field cron expressions without scanning every minute in the requested range.

Repository: https://github.com/jaysobel/dbt-cron-timestamps

Release: https://github.com/jaysobel/dbt-cron-timestamps/releases/tag/1.1.1

The core SQL approach originated in a real warehouse scheduling use case for converting cron schedules into effective start/end intervals. The formal package release adds an independently generated exact fixture, a 1,000-expression stress suite, and validation against `cronsim`, `croniter`, dbt Core, dbt Fusion, and Snowflake.

## Checklist

### Real world usage

- [x] (Required): The underlying implementation originated in production warehouse scheduling work and I am satisfied with its behavior. The public package form is newly released; its production lineage and new validation are described above.

### First run experience

- [x] (Required): The package includes a GitHub-detectable MIT license.
- [x] The package includes a README explaining installation, both public macros, cron semantics, and configuration.
- [x] The README identifies Snowflake as the supported warehouse.

### Customisability

- [x] The macros accept caller-provided CTE and column names and do not hard-code table references.
- [x] The package exposes bounded ranges, day-matching modes, interval limits, and input timezone configuration.

The source-table-location checklist is not applicable because this is a utility macro package and includes no transformation models or sources.

### Dependencies

- [x] The package declares `require-dbt-version: [">=1.5.0", "<3.0.0"]`, validated with dbt Core 1.5, 1.8, 1.10, and 1.12 families plus dbt Fusion 2.0 preview.

The package has no dependencies on other dbt packages.

### Interoperability

- [x] The package does not override dbt Core behavior or configure consumer resources.
- [x] Resource and public macro names are scoped under `dbt_cron_timestamps`.

Cross-database macros are not applicable: the package deliberately uses Snowflake-native SQL for constructive timestamp generation and documents Snowflake as its only supported adapter.

### Versioning

- [x] (Required): The `1.1.1` release tag validates against Hubcap's semantic-version parser.
- [x] Version `1.1.1` follows Semantic Versioning and is documented in the changelog.

## Validation

- Hubcap JSON parses successfully.
- Hubcap test suite: 154 passed, 14 expected failures, 3 expected passes.
- Package CI validates dbt Core 1.5, 1.8, and 1.10 families plus dbt Fusion.
- Local dbt Core 1.12 and Fusion 2.0 each seeded 67,165 expected timestamps and passed all six Snowflake integration tests.
