### PR TITLE
Add real-world usage to best practices document

### DIFF
--- a/package-best-practices.md
+++ b/package-best-practices.md
@@ -12,6 +12,11 @@ To avoid ambiguity, the bullets below are pretty formal, but we are a friendly b
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
+### Real world usage
+- Packages MUST have been used in the author's own production environment for an extended period of time before being submitted to the dbt Package Hub.
+    - Using coding agents to help build a package is completely fine, but a package's behaviour SHOULD be proven by real usage rather than by review alone.
+- Package authors SHOULD be satisfied with their package's behaviour in production at the time of submission.
+
 ### First run experience
 - Packages MUST include a [licence file detectable by GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository). We strongly encourage an open source licence such as Apache 2.0 or MIT.
 - Packages SHOULD contain a README file which explains how to get started with the package and customise its behaviour.

--- a/package-best-practices.md
+++ b/package-best-practices.md
@@ -13,9 +13,9 @@ To avoid ambiguity, the bullets below are pretty formal, but we are a friendly b
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
 ### Real world usage
-- Packages MUST have been used in the author's own production environment for an extended period of time before being submitted to the dbt Package Hub.
-    - Using coding agents to help build a package is completely fine, but a package's behaviour SHOULD be proven by real usage rather than by review alone.
-- Package authors SHOULD be satisfied with their package's behaviour in production at the time of submission.
+- Using coding agents to help build a package is completely fine, but package authors MUST be satisfied with their package's behaviour in production at the time of submission. For example:
+    - Packages SHOULD have been used in the author's own production environment for an extended period of time before being submitted to the dbt Package Hub.
+    - Packages SHOULD contain git history more extensive than "initial commit", demonstrating changes made based on the author's experience with the package instead of a one-shotted project.
 
 ### First run experience
 - Packages MUST include a [licence file detectable by GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository). We strongly encourage an open source licence such as Apache 2.0 or MIT.


### PR DESCRIPTION
resolves #439

### Problem

We say that the [checklist](https://github.com/dbt-labs/hubcap/blob/c271d1ed3f8e2359baf6e4ab34feca1669f160f1/.github/pull_request_template.md) is a "cut down version of the [best practices](https://github.com/dbt-labs/hubcap/blob/c271d1ed3f8e2359baf6e4ab34feca1669f160f1/blob/main/package-best-practices.md)".

But after https://github.com/dbt-labs/hubcap/commit/362f8aeec8075a76535526f84806b07e21234994, we have some drift.

### Solution

Update the best practices doc to add "real world usage" requirement.